### PR TITLE
Composite aggregations - tabular parsing support

### DIFF
--- a/pandagg/node/aggs/abstract.py
+++ b/pandagg/node/aggs/abstract.py
@@ -129,6 +129,9 @@ class AggClause(Node):
             return {attr_: response.get(attr_) for attr_ in attrs}
         return response.get(attrs[0])
 
+    def is_convertible_to_composite_source(self) -> bool:
+        return False
+
     def __str__(self) -> str:
         return "<{class_}, type={type}, body={body}>".format(
             class_=str(self.__class__.__name__),

--- a/pandagg/node/aggs/bucket.py
+++ b/pandagg/node/aggs/bucket.py
@@ -136,6 +136,14 @@ class Terms(MultipleBucketAgg):
             return {"bool": {"must_not": {"exists": {"field": self.field}}}}
         return {"term": {self.field: {"value": key}}}
 
+    def is_convertible_to_composite_source(self) -> bool:
+        # TODO: elasticsearch documentation is unclear about which body clauses are accepted as a source, for now just
+        # sure that 'include'/'exclude' are not supported as composite source:
+        # https://github.com/elastic/elasticsearch/issues/50368
+        if "include" in self.body or "exclude" in self.body:
+            return False
+        return True
+
 
 class Filters(MultipleBucketAgg):
 
@@ -205,6 +213,9 @@ class Histogram(MultipleBucketAgg):
             )
         return {"range": {self.field: {"gte": key_, "lt": key_ + self.interval}}}
 
+    def is_convertible_to_composite_source(self) -> bool:
+        return True
+
 
 class DateHistogram(MultipleBucketAgg):
     KEY = "date_histogram"
@@ -255,6 +266,9 @@ class DateHistogram(MultipleBucketAgg):
         return {
             "range": {self.field: {"gte": key, "lt": "%s||+%s" % (key, self.interval)}}
         }
+
+    def is_convertible_to_composite_source(self) -> bool:
+        return True
 
 
 class Range(MultipleBucketAgg):

--- a/pandagg/node/aggs/composite.py
+++ b/pandagg/node/aggs/composite.py
@@ -41,6 +41,10 @@ class Composite(BucketAggClause):
             body["after_key"] = after_key
         super(Composite, self).__init__(meta=meta, sources=sources, **body)
 
+    @property
+    def source_names(self) -> List[AggName]:
+        return [n for source in self._sources for n in source.keys()]
+
     def extract_buckets(
         self, response_value: AggClauseResponseDict
     ) -> Iterator[Tuple[CompositeBucketKey, BucketDict]]:

--- a/pandagg/response.py
+++ b/pandagg/response.py
@@ -468,7 +468,7 @@ class Aggregations:
     def to_tabular(
         self,
         *,
-        index_orient: Literal[True],
+        index_orient: Literal[True] = True,
         grouped_by: Optional[AggName] = None,
         expand_columns: bool = True,
         expand_sep: str = "|",

--- a/pandagg/search.py
+++ b/pandagg/search.py
@@ -21,7 +21,7 @@ from elasticsearch.helpers import scan
 
 from pandagg.node.aggs.abstract import TypeOrAgg
 from pandagg.query import Bool
-from pandagg.response import SearchResponse, Hit
+from pandagg.response import SearchResponse, Hit, Aggregations
 from pandagg.tree.mappings import _mappings, Mappings
 from pandagg.tree.query import (
     Query,
@@ -39,6 +39,8 @@ from pandagg.types import (
     SearchResponseDict,
     DeleteByQueryResponse,
     SearchDict,
+    BucketDict,
+    AfterKey,
 )
 from pandagg.utils import DSLMixin
 
@@ -787,6 +789,37 @@ class Search(DSLMixin, Request):
         es = self._get_connection()
         raw_data = es.search(index=self._index, body=self.to_dict())
         return SearchResponse(data=raw_data, _search=self)
+
+    def scan_composite_agg(self, size: int) -> Iterator[BucketDict]:
+        """Iterate over the whole aggregation composed buckets, yields buckets."""
+        s: Search = self._clone()
+        s._aggs = s._aggs.as_composite(size=size)
+
+        a_name, _ = s._aggs.get_composition_supporting_agg()
+
+        r: SearchResponse = s.execute()
+        buckets: List[BucketDict] = r.aggregations.data[a_name][  # type: ignore
+            "buckets"
+        ]
+        after_key: AfterKey = r.aggregations.data[a_name]["after_key"]  # type: ignore
+
+        while len(buckets) == size:
+            s._aggs = s._aggs.as_composite(size=size, after=after_key)
+            r = s.execute()
+            buckets = r.aggregations.data[a_name]["buckets"]  # type: ignore
+            after_key = r.aggregations.data[a_name]["after_key"]  # type: ignore
+            for bucket in buckets:
+                yield bucket
+
+    def scan_composite_agg_at_once(self, size: int) -> Aggregations:
+        """Iterate over the whole aggregation composed buckets (converting Aggs into composite agg if possible), and
+        return all buckets at once in a Aggregations instance.
+        """
+        all_buckets = list(self.scan_composite_agg(size=size))
+        agg_name: AggName
+        agg_name, _ = self._aggs.get_composition_supporting_agg()  # type: ignore
+        # artificially merge all buckets as if they were returned in a single query
+        return Aggregations(_search=self, data={agg_name: {"buckets": all_buckets}})
 
     def scan(self) -> Iterator[Hit]:
         """

--- a/pandagg/search.py
+++ b/pandagg/search.py
@@ -792,34 +792,40 @@ class Search(DSLMixin, Request):
 
     def scan_composite_agg(self, size: int) -> Iterator[BucketDict]:
         """Iterate over the whole aggregation composed buckets, yields buckets."""
-        s: Search = self._clone()
+        s: Search = self._clone().size(0)
         s._aggs = s._aggs.as_composite(size=size)
-
         a_name, _ = s._aggs.get_composition_supporting_agg()
-
         r: SearchResponse = s.execute()
         buckets: List[BucketDict] = r.aggregations.data[a_name][  # type: ignore
             "buckets"
         ]
         after_key: AfterKey = r.aggregations.data[a_name]["after_key"]  # type: ignore
 
-        while len(buckets) == size:
+        init: bool = True
+        while init or len(buckets) == size:
+            init = False
             s._aggs = s._aggs.as_composite(size=size, after=after_key)
             r = s.execute()
-            buckets = r.aggregations.data[a_name]["buckets"]  # type: ignore
-            after_key = r.aggregations.data[a_name]["after_key"]  # type: ignore
+            agg_clause_response = r.aggregations.data[a_name]
+            buckets = agg_clause_response["buckets"]  # type: ignore
             for bucket in buckets:
                 yield bucket
+            if "after_key" in agg_clause_response:
+                after_key = agg_clause_response["after_key"]  # type: ignore
+            else:
+                break
 
     def scan_composite_agg_at_once(self, size: int) -> Aggregations:
         """Iterate over the whole aggregation composed buckets (converting Aggs into composite agg if possible), and
         return all buckets at once in a Aggregations instance.
         """
         all_buckets = list(self.scan_composite_agg(size=size))
+        s: Search = self._clone().size(0)
+        s._aggs = s._aggs.as_composite(size=size)
         agg_name: AggName
-        agg_name, _ = self._aggs.get_composition_supporting_agg()  # type: ignore
+        agg_name, _ = s._aggs.get_composition_supporting_agg()  # type: ignore
         # artificially merge all buckets as if they were returned in a single query
-        return Aggregations(_search=self, data={agg_name: {"buckets": all_buckets}})
+        return Aggregations(_search=s, data={agg_name: {"buckets": all_buckets}})
 
     def scan(self) -> Iterator[Hit]:
         """

--- a/pandagg/tree/aggs.py
+++ b/pandagg/tree/aggs.py
@@ -613,11 +613,15 @@ class Aggs(TreeReprMixin, Tree[AggClause]):
         _, below_aggs = self.subtree(nid=agg_to_convert.identifier)
         initial_grouping_agg: AggName = self.get_key(self._groupby_ptr)  # type: ignore
 
-        a: Aggs = self.clone(with_nodes=False)
         return (
-            a.groupby(
+            self.clone(with_nodes=False)
+            .groupby(
                 agg_name,
-                Composite(size=size, sources=[agg_to_convert.to_dict()], after=after),
+                Composite(
+                    size=size,
+                    sources=[{agg_name: agg_to_convert.to_dict()}],
+                    after=after,
+                ),
             )
             .aggs(below_aggs)
             .grouped_by(agg_name=initial_grouping_agg)

--- a/pandagg/tree/query.py
+++ b/pandagg/tree/query.py
@@ -463,7 +463,7 @@ class Query(Tree[QueryClause]):
 
     __bool__ = __nonzero__
 
-    def _clone_init(self, deep: bool_ = False) -> "Query":
+    def _clone_init(self, deep: bool_, with_nodes: bool_) -> "Query":
         return Query(
             mappings=None
             if self.mappings is None

--- a/pandagg/tree/response.py
+++ b/pandagg/tree/response.py
@@ -133,7 +133,7 @@ class AggsResponseTree(TreeReprMixin, Tree[Bucket]):
             nid_to_children[nearest_nested_parent.identifier].add(nested)
         return self._build_filter(nid_to_children, filters_per_nested_level).to_dict()
 
-    def _clone_init(self, deep: bool = False) -> "AggsResponseTree":
+    def _clone_init(self, deep: bool, with_nodes: bool) -> "AggsResponseTree":
         return AggsResponseTree(aggs=self.__aggs.clone(deep=deep))
 
     def _parse_node_with_children(

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, "README.md")).read()
 
 install_requires = [
-    "lighttree==1.3.3",
+    "lighttree==1.3.4",
     "elasticsearch>=7.0.0,<8.0.0",
     "typing_extensions",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from elasticsearch.helpers import bulk
 from elasticsearch.helpers.test import get_test_client
 
 
-from .test_data import TEST_GIT_DATA, create_git_index
+from .test_data import TEST_GIT_DATA, create_git_index, GIT_MAPPINGS
 
 
 @fixture(scope="session")
@@ -36,6 +36,11 @@ def mock_client(dummy_response):
     client = Mock()
     client.search.return_value = dummy_response
     return client
+
+
+@fixture
+def git_mappings():
+    return GIT_MAPPINGS
 
 
 @fixture(scope="session")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,23 +5,34 @@ from typing import List, Any, Dict
 from typing_extensions import TypedDict
 
 
-def git_mappings():
-    # we will use user on several places
-    user_mapping = {
-        "properties": {"name": {"type": "text", "fields": {"raw": {"type": "keyword"}}}}
-    }
-    return {
-        "dynamic": False,
-        "properties": {
-            "description": {"type": "text", "analyzer": "snowball"},
-            "author": user_mapping,
-            "authored_date": {"type": "date"},
-            "committer": user_mapping,
-            "committed_date": {"type": "date"},
-            "parent_shas": {"type": "keyword"},
-            "files": {"type": "text", "analyzer": "file_path", "fielddata": True},
+GIT_MAPPINGS = {
+    "dynamic": False,
+    "properties": {
+        "description": {"type": "text", "analyzer": "snowball"},
+        "author": {
+            "properties": {
+                "name": {"type": "text", "fields": {"raw": {"type": "keyword"}}}
+            }
         },
-    }
+        "stats": {
+            "properties": {
+                "insertions": {"type": "integer"},
+                "lines": {"type": "integer"},
+                "files": {"type": "integer"},
+                "deletions": {"type": "integer"},
+            }
+        },
+        "authored_date": {"type": "date"},
+        "committer": {
+            "properties": {
+                "name": {"type": "text", "fields": {"raw": {"type": "keyword"}}}
+            }
+        },
+        "committed_date": {"type": "date"},
+        "parent_shas": {"type": "keyword"},
+        "files": {"type": "text", "analyzer": "file_path", "fielddata": True},
+    },
+}
 
 
 def create_git_index(client, index):
@@ -44,7 +55,7 @@ def create_git_index(client, index):
                     }
                 },
             },
-            "mappings": git_mappings(),
+            "mappings": GIT_MAPPINGS,
         },
     )
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -5,7 +5,7 @@ from pandagg.discovery import discover, Index
 from mock import patch
 
 from pandagg.interactive.mappings import IMappings
-from tests.test_data import git_mappings
+from tests.test_data import GIT_MAPPINGS
 from tests.testing_samples.mapping_example import MAPPINGS
 from tests.testing_samples.settings_example import SETTINGS
 
@@ -47,6 +47,6 @@ class TestDiscovery:
         existing_mappings = git.mappings.copy()
         # False cast to "false" in ES apis for some reason
         existing_mappings.pop("dynamic")
-        expected_mappings = git_mappings().copy()
+        expected_mappings = GIT_MAPPINGS.copy()
         expected_mappings.pop("dynamic")
         assert existing_mappings == expected_mappings

--- a/tests/tree/aggs/test_aggs.py
+++ b/tests/tree/aggs/test_aggs.py
@@ -1,4 +1,6 @@
 from unittest import TestCase
+
+import pytest
 from mock import patch
 
 from pandagg.tree.aggs import Aggs
@@ -948,3 +950,113 @@ A                                                             <terms, field="a">
                 }
             },
         )
+
+    def test_get_composition_supporting_agg(self):
+        # OK
+        name, agg_clause = (
+            Aggs()
+            .agg("compatible_terms", "terms", field="some_field")
+            .get_composition_supporting_agg()
+        )
+        assert name == "compatible_terms"
+        assert isinstance(agg_clause, Terms)
+
+        # OK
+        name, agg_clause = (
+            Aggs()
+            .groupby("compatible_terms", "terms", field="some_field")
+            .agg("max_metric", "max", field="some_other_field")
+            .get_composition_supporting_agg()
+        )
+        assert name == "compatible_terms"
+        assert isinstance(agg_clause, Terms)
+
+        # Not OK, since include is not authorized as source in term composition
+        with pytest.raises(ValueError) as e:
+            Aggs().agg(
+                "incompatible_terms", "terms", field="some_field", include="pref.*"
+            ).get_composition_supporting_agg()
+        assert e.value.args == (
+            "<incompatible_terms> agg clause is not convertible into a composite aggregation.",
+        )
+
+        # Not OK, because incompatible agg type
+        with pytest.raises(ValueError) as e:
+            Aggs().agg(
+                "incompatible_metric", "max", field="some_field"
+            ).get_composition_supporting_agg()
+        assert e.value.args == (
+            "<incompatible_metric> agg clause is not convertible into a composite "
+            "aggregation.",
+        )
+
+        # Not OK because there are two clauses at the root of the aggregation
+        with pytest.raises(ValueError) as e:
+            Aggs().aggs(
+                {
+                    "user_id": {"terms": {"field": "user.id"}},
+                    "user_name": {"terms": {"field": "user.name"}},
+                }
+            ).get_composition_supporting_agg()
+        assert e.value.args == (
+            "There can be only one root aggregation clause to be able to convert it into a composite aggregation.",
+        )
+
+    def test_as_composite(self):
+        # terms converted
+        initial_agg = (
+            Aggs()
+            .groupby("compatible_terms", "terms", field="some_field")
+            .agg("max_metric", "max", field="some_other_field")
+        )
+
+        comp_agg = initial_agg.as_composite(size=10)
+
+        assert isinstance(comp_agg, Aggs)
+        assert comp_agg.to_dict() == {
+            "compatible_terms": {
+                "composite": {
+                    "size": 10,
+                    "sources": [{"terms": {"field": "some_field"}}],
+                },
+                "aggs": {"max_metric": {"max": {"field": "some_other_field"}}},
+            }
+        }
+        # ensure initial agg wasn't modified
+        assert initial_agg.to_dict() == {
+            "compatible_terms": {
+                "aggs": {"max_metric": {"max": {"field": "some_other_field"}}},
+                "terms": {"field": "some_field"},
+            }
+        }
+
+        initial_agg = (
+            Aggs()
+            .groupby(
+                "compatible_terms",
+                "composite",
+                sources=[{"terms_source": {"field": "some_field"}}],
+            )
+            .agg("max_metric", "max", field="some_other_field")
+        )
+
+        # composite modified
+        comp_agg = initial_agg.as_composite(size=10, after={"terms_source": "yolo"})
+        assert isinstance(comp_agg, Aggs)
+        assert comp_agg.to_dict() == {
+            "compatible_terms": {
+                "aggs": {"max_metric": {"max": {"field": "some_other_field"}}},
+                "composite": {
+                    "after": {"terms_source": "yolo"},
+                    "size": 10,
+                    "sources": [{"terms_source": {"field": "some_field"}}],
+                },
+            }
+        }
+        # ensure initial agg wasn't modified
+        assert initial_agg.to_dict() == {
+            "compatible_terms": {
+                "aggs": {"max_metric": {"max": {"field": "some_other_field"}}},
+                "composite": {"sources": [{"terms_source": {"field": "some_field"}}]},
+            }
+        }

--- a/tests/tree/aggs/test_aggs.py
+++ b/tests/tree/aggs/test_aggs.py
@@ -1017,7 +1017,9 @@ A                                                             <terms, field="a">
             "compatible_terms": {
                 "composite": {
                     "size": 10,
-                    "sources": [{"terms": {"field": "some_field"}}],
+                    "sources": [
+                        {"compatible_terms": {"terms": {"field": "some_field"}}}
+                    ],
                 },
                 "aggs": {"max_metric": {"max": {"field": "some_other_field"}}},
             }


### PR DESCRIPTION
This PR aims to implement composite aggregations support, notably for aggregations response parsing in tabular format. Composite aggregations are special since they will generate a grouping column per source (1->N) whereas regular aggregation clauses generate a single column.

Relates to https://github.com/alkemics/pandagg/issues/57, mentioned on https://github.com/alkemics/pandagg/issues/72.
