### PR TITLE
Bucket aggs: add missing clauses

### DIFF
--- a/pandagg/aggs.py
+++ b/pandagg/aggs.py
@@ -23,6 +23,7 @@ from pandagg.node.aggs.bucket import (
     DiversifiedSampler,
     Children,
     Parent,
+    SignificantText,
 )
 
 from pandagg.node.aggs.composite import Composite
@@ -116,4 +117,5 @@ __all__ = [
     "DiversifiedSampler",
     "Children",
     "Parent",
+    "SignificantText",
 ]

--- a/pandagg/aggs.py
+++ b/pandagg/aggs.py
@@ -24,6 +24,7 @@ from pandagg.node.aggs.bucket import (
     Children,
     Parent,
     SignificantText,
+    MultiTerms,
 )
 
 from pandagg.node.aggs.composite import Composite
@@ -118,4 +119,5 @@ __all__ = [
     "Children",
     "Parent",
     "SignificantText",
+    "MultiTerms",
 ]

--- a/pandagg/aggs.py
+++ b/pandagg/aggs.py
@@ -21,6 +21,7 @@ from pandagg.node.aggs.bucket import (
     IPRange,
     Sampler,
     DiversifiedSampler,
+    Children,
 )
 
 from pandagg.node.aggs.composite import Composite
@@ -112,4 +113,5 @@ __all__ = [
     "IPRange",
     "Sampler",
     "DiversifiedSampler",
+    "Children",
 ]

--- a/pandagg/aggs.py
+++ b/pandagg/aggs.py
@@ -22,6 +22,7 @@ from pandagg.node.aggs.bucket import (
     Sampler,
     DiversifiedSampler,
     Children,
+    Parent,
 )
 
 from pandagg.node.aggs.composite import Composite
@@ -114,4 +115,5 @@ __all__ = [
     "Sampler",
     "DiversifiedSampler",
     "Children",
+    "Parent",
 ]

--- a/pandagg/node/aggs/abstract.py
+++ b/pandagg/node/aggs/abstract.py
@@ -243,10 +243,10 @@ class BucketAggClause(AggClause):
     >>> )
     """
 
-    def __init__(self, meta: Optional[Meta] = None, **body: Any) -> None:
+    def __init__(self, **body: Any) -> None:
         identifier: Optional[str] = body.pop("identifier", None)
         aggs = body.pop("aggs", None) or body.pop("aggregations", None)
-        super(BucketAggClause, self).__init__(identifier=identifier, meta=meta, **body)
+        super(BucketAggClause, self).__init__(identifier=identifier, **body)
         self._children: Dict[AggName, Any] = aggs or {}  # type: ignore
 
     def extract_buckets(
@@ -270,11 +270,7 @@ class MultipleBucketAgg(BucketAggClause):
     IMPLICIT_KEYED: bool = False
 
     def __init__(
-        self,
-        keyed: bool = False,
-        key_as_string: bool = False,
-        meta: Meta = None,
-        **body: Any
+        self, keyed: bool = False, key_as_string: bool = False, **body: Any
     ) -> None:
         """
         Aggregation that return either a list or a map of buckets.
@@ -287,7 +283,7 @@ class MultipleBucketAgg(BucketAggClause):
         self.key_path: str = "key_as_string" if key_as_string else "key"
         if keyed and not self.IMPLICIT_KEYED:
             body["keyed"] = keyed
-        super(MultipleBucketAgg, self).__init__(meta=meta, **body)
+        super(MultipleBucketAgg, self).__init__(**body)
 
     def extract_buckets(
         self, response_value: AggClauseResponseDict
@@ -313,28 +309,18 @@ class FieldOrScriptMetricAgg(MetricAgg):
     """
 
     def __init__(
-        self,
-        field: Optional[str] = None,
-        script: Optional[Script] = None,
-        meta: Optional[Meta] = None,
-        **body: Any
+        self, field: Optional[str] = None, script: Optional[Script] = None, **body: Any
     ) -> None:
         self.field: Optional[str] = field
-        super(FieldOrScriptMetricAgg, self).__init__(
-            field=field, script=script, meta=meta, **body
-        )
+        super(FieldOrScriptMetricAgg, self).__init__(field=field, script=script, **body)
 
 
 class Pipeline(UniqueBucketAgg):
     def __init__(
-        self,
-        buckets_path: str,
-        gap_policy: Optional[GapPolicy] = None,
-        meta: Optional[Meta] = None,
-        **body: Any
+        self, buckets_path: str, gap_policy: Optional[GapPolicy] = None, **body: Any
     ) -> None:
         super(Pipeline, self).__init__(
-            buckets_path=buckets_path, gap_policy=gap_policy, meta=meta, **body
+            buckets_path=buckets_path, gap_policy=gap_policy, **body
         )
 
 
@@ -346,13 +332,8 @@ class ScriptPipeline(Pipeline):
         script: Script,
         buckets_path: str,
         gap_policy: Optional[GapPolicy] = None,
-        meta: Optional[Meta] = None,
         **body: Any
     ) -> None:
         super(ScriptPipeline, self).__init__(
-            buckets_path=buckets_path,
-            gap_policy=gap_policy,
-            meta=meta,
-            script=script,
-            **body
+            buckets_path=buckets_path, gap_policy=gap_policy, script=script, **body
         )

--- a/pandagg/node/aggs/abstract.py
+++ b/pandagg/node/aggs/abstract.py
@@ -43,7 +43,7 @@ class AggClause(Node):
     ) -> None:
         # remove empty keys from body, make __init__ clearer
         self.body: Dict[str, Any] = {k: v for k, v in body.items() if v is not None}
-        self.meta: Optional[Dict[str, Any]] = meta
+        self.meta: Optional[Meta] = meta
         self._children: Dict[AggName, Any] = {}
         super(AggClause, self).__init__(identifier=identifier)
 

--- a/pandagg/node/aggs/bucket.py
+++ b/pandagg/node/aggs/bucket.py
@@ -1,5 +1,4 @@
 """Not implemented aggregations include:
-- children
 - parent
 - multi-terms
 - significant text
@@ -110,6 +109,14 @@ class DiversifiedSampler(UniqueBucketAgg):
             execution_hint=execution_hint,
             **body
         )
+
+
+class Children(UniqueBucketAgg):
+    KEY = "children"
+    VALUE_ATTRS = ["doc_count"]
+
+    def __init__(self, type: str, **body: Any) -> None:
+        super(Children, self).__init__(type=type, **body)
 
 
 class Terms(MultipleBucketAgg):

--- a/pandagg/node/aggs/bucket.py
+++ b/pandagg/node/aggs/bucket.py
@@ -1,5 +1,4 @@
 """Not implemented aggregations include:
-- parent
 - multi-terms
 - significant text
 """
@@ -117,6 +116,14 @@ class Children(UniqueBucketAgg):
 
     def __init__(self, type: str, **body: Any) -> None:
         super(Children, self).__init__(type=type, **body)
+
+
+class Parent(UniqueBucketAgg):
+    KEY = "parent"
+    VALUE_ATTRS = ["doc_count"]
+
+    def __init__(self, type: str, **body: Any) -> None:
+        super(Parent, self).__init__(type=type, **body)
 
 
 class Terms(MultipleBucketAgg):

--- a/pandagg/node/aggs/bucket.py
+++ b/pandagg/node/aggs/bucket.py
@@ -27,7 +27,10 @@ class Filter(UniqueBucketAgg):
     VALUE_ATTRS = ["doc_count"]
 
     def __init__(
-        self, filter: Optional[QueryClauseDict] = None, meta: Meta = None, **body: Any
+        self,
+        filter: Optional[QueryClauseDict] = None,
+        meta: Optional[Meta] = None,
+        **body: Any
     ):
         if (filter is not None) != (not body):
             raise ValueError(
@@ -41,8 +44,8 @@ class Filter(UniqueBucketAgg):
 
 
 class MatchAll(Filter):
-    def __init__(self, meta: Meta = None, **body: Any):
-        super(MatchAll, self).__init__(filter={"match_all": {}}, meta=meta, **body)
+    def __init__(self, **body: Any):
+        super(MatchAll, self).__init__(filter={"match_all": {}}, **body)
 
 
 class Nested(UniqueBucketAgg):
@@ -51,9 +54,9 @@ class Nested(UniqueBucketAgg):
     VALUE_ATTRS = ["doc_count"]
     WHITELISTED_MAPPING_TYPES = ["nested"]
 
-    def __init__(self, path: str, meta: Meta = None, **body: Any):
+    def __init__(self, path: str, **body: Any):
         self.path: str = path
-        super(Nested, self).__init__(path=path, meta=meta, **body)
+        super(Nested, self).__init__(path=path, **body)
 
 
 class ReverseNested(UniqueBucketAgg):
@@ -62,18 +65,18 @@ class ReverseNested(UniqueBucketAgg):
     VALUE_ATTRS = ["doc_count"]
     WHITELISTED_MAPPING_TYPES = ["nested"]
 
-    def __init__(self, path: Optional[str] = None, meta: Meta = None, **body: Any):
+    def __init__(self, path: Optional[str] = None, **body: Any) -> None:
         self.path: Optional[str] = path
-        super(ReverseNested, self).__init__(meta=meta, path=path, **body)
+        super(ReverseNested, self).__init__(path=path, **body)
 
 
 class Missing(UniqueBucketAgg):
     KEY = "missing"
     VALUE_ATTRS = ["doc_count"]
 
-    def __init__(self, field: str, meta: Meta = None, **body: Any):
+    def __init__(self, field: str, **body: Any) -> None:
         self.field: str = field
-        super(Missing, self).__init__(field=field, meta=meta, **body)
+        super(Missing, self).__init__(field=field, **body)
 
 
 class Sampler(UniqueBucketAgg):
@@ -120,13 +123,10 @@ class Terms(MultipleBucketAgg):
         field: str,
         missing: Optional[Union[int, str]] = None,
         size: Optional[int] = None,
-        meta: Optional[Meta] = None,
         **body: Any
     ) -> None:
         self.field: str = field
-        super(Terms, self).__init__(
-            field=field, missing=missing, size=size, meta=meta, **body
-        )
+        super(Terms, self).__init__(field=field, missing=missing, size=size, **body)
 
     def is_convertible_to_composite_source(self) -> bool:
         # TODO: elasticsearch documentation is unclear about which body clauses are accepted as a source, for now just
@@ -149,14 +149,12 @@ class Filters(MultipleBucketAgg):
         filters: Dict[str, QueryClauseDict],
         other_bucket: bool = False,
         other_bucket_key: Optional[str] = None,
-        meta: Optional[Meta] = None,
         **body: Any
     ) -> None:
         super(Filters, self).__init__(
             filters=filters,
             other_bucket=other_bucket,
             other_bucket_key=other_bucket_key,
-            meta=meta,
             **body
         )
 
@@ -170,11 +168,10 @@ class AdjacencyMatrix(MultipleBucketAgg):
         self,
         filters: Dict[str, QueryClauseDict],
         separator: Optional[str] = None,
-        meta: Optional[Meta] = None,
         **body: Any
     ) -> None:
         super(AdjacencyMatrix, self).__init__(
-            filters=filters, separator=separator, meta=meta, **body
+            filters=filters, separator=separator, **body
         )
 
 
@@ -184,13 +181,9 @@ class Histogram(MultipleBucketAgg):
     VALUE_ATTRS = ["doc_count"]
     WHITELISTED_MAPPING_TYPES = NUMERIC_TYPES
 
-    def __init__(
-        self, field: str, interval: int, meta: Optional[Meta] = None, **body: Any
-    ) -> None:
+    def __init__(self, field: str, interval: int, **body: Any) -> None:
         self.field: str = field
-        super(Histogram, self).__init__(
-            field=field, interval=interval, meta=meta, **body
-        )
+        super(Histogram, self).__init__(field=field, interval=interval, **body)
 
     def is_convertible_to_composite_source(self) -> bool:
         return True
@@ -207,7 +200,6 @@ class DateHistogram(MultipleBucketAgg):
         interval: str = None,
         calendar_interval: str = None,
         fixed_interval: str = None,
-        meta: Meta = None,
         key_as_string: bool = True,
         **body: Any
     ) -> None:
@@ -227,7 +219,6 @@ class DateHistogram(MultipleBucketAgg):
             interval=interval,
             calendar_interval=calendar_interval,
             fixed_interval=fixed_interval,
-            meta=meta,
             key_as_string=key_as_string,
             **body
         )
@@ -265,7 +256,6 @@ class AutoDateHistogram(MultipleBucketAgg):
         time_zone: Optional[str] = None,
         minimum_interval: Optional[str] = None,
         missing: Optional[str] = None,
-        meta: Optional[Meta] = None,
         key_as_string: bool = True,
         **body: Any
     ) -> None:
@@ -277,7 +267,6 @@ class AutoDateHistogram(MultipleBucketAgg):
             time_zone=time_zone,
             minimum_interval=minimum_interval,
             missing=missing,
-            meta=meta,
             key_as_string=key_as_string,
             **body
         )
@@ -289,17 +278,10 @@ class Range(MultipleBucketAgg):
     WHITELISTED_MAPPING_TYPES = NUMERIC_TYPES
 
     def __init__(
-        self,
-        field: str,
-        ranges: List[RangeDict],
-        keyed: bool = False,
-        meta: Optional[Meta] = None,
-        **body: Any
+        self, field: str, ranges: List[RangeDict], keyed: bool = False, **body: Any
     ) -> None:
         self.field: str = field
-        super(Range, self).__init__(
-            field=field, ranges=ranges, keyed=keyed, meta=meta, **body
-        )
+        super(Range, self).__init__(field=field, ranges=ranges, keyed=keyed, **body)
 
 
 class DateRange(Range):
@@ -327,7 +309,6 @@ class GeoDistance(Range):
         unit: Optional[str] = None,
         distance_type: Optional[DistanceType] = None,
         keyed: bool = False,
-        meta: Optional[Meta] = None,
         **body: Any
     ) -> None:
         super(Range, self).__init__(
@@ -337,7 +318,6 @@ class GeoDistance(Range):
             unit=unit,
             distance_type=distance_type,
             keyed=keyed,
-            meta=meta,
             **body
         )
 

--- a/pandagg/node/aggs/bucket.py
+++ b/pandagg/node/aggs/bucket.py
@@ -17,8 +17,8 @@ class Global(UniqueBucketAgg):
     KEY = "global"
     VALUE_ATTRS = ["doc_count"]
 
-    def __init__(self, meta: Meta = None):
-        super(Global, self).__init__(agg_body={}, meta=meta)
+    def __init__(self, **body: Any) -> None:
+        super(Global, self).__init__(**body)
 
 
 class Filter(UniqueBucketAgg):

--- a/pandagg/node/aggs/bucket.py
+++ b/pandagg/node/aggs/bucket.py
@@ -1,6 +1,4 @@
-"""Not implemented aggregations include:
-- multi-terms
-"""
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket.html
 
 from typing import Any, Optional, Dict, Union, List
 
@@ -437,3 +435,14 @@ class RareTerms(MultipleBucketAgg):
             missing=missing,
             **body
         )
+
+
+class MultiTerms(MultipleBucketAgg):
+    KEY = "multi_terms"
+    VALUE_ATTRS = ["doc_count", "doc_count_error_upper_bound", "sum_other_doc_count"]
+
+    def __init__(self, terms: List[Dict], **body: Any) -> None:
+        """
+        https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-multi-terms-aggregation.html
+        """
+        super(MultiTerms, self).__init__(terms=terms, key_as_string=True, **body)

--- a/pandagg/node/aggs/bucket.py
+++ b/pandagg/node/aggs/bucket.py
@@ -1,6 +1,5 @@
 """Not implemented aggregations include:
 - multi-terms
-- significant text
 """
 
 from typing import Any, Optional, Dict, Union, List
@@ -396,6 +395,19 @@ class SignificantTerms(MultipleBucketAgg):
         """
         self.field = field
         super(SignificantTerms, self).__init__(field=field, **body)
+
+
+class SignificantText(MultipleBucketAgg):
+    KEY = "significant_text"
+    VALUE_ATTRS = ["doc_count", "score", "bg_count"]
+    WHITELISTED_MAPPING_TYPES = ["text"]
+
+    def __init__(self, field: str, **body: Any) -> None:
+        """
+        https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significanttext-aggregation.html
+        """
+        self.field = field
+        super(SignificantText, self).__init__(field=field, **body)
 
 
 class RareTerms(MultipleBucketAgg):

--- a/pandagg/node/aggs/composite.py
+++ b/pandagg/node/aggs/composite.py
@@ -1,7 +1,6 @@
 from .abstract import BucketAggClause
 from typing import Optional, Any, Dict, List, Iterator, Tuple
 from pandagg.types import (
-    Meta,
     AfterKey,
     CompositeSource,
     BucketDict,
@@ -21,13 +20,10 @@ class Composite(BucketAggClause):
         sources: List[Dict[AggName, CompositeSource]],
         size: Optional[int] = None,
         after: Optional[AfterKey] = None,
-        meta: Meta = None,
         **body: Any
     ):
         """https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html"""  # noqa: E501
-        super(Composite, self).__init__(
-            sources=sources, size=size, after=after, meta=meta, **body
-        )
+        super(Composite, self).__init__(sources=sources, size=size, after=after, **body)
 
     @property
     def after(self) -> Optional[AfterKey]:

--- a/pandagg/node/aggs/metric.py
+++ b/pandagg/node/aggs/metric.py
@@ -1,8 +1,7 @@
-from typing import Optional, Any, List
+from typing import Any, List
 
 from pandagg.node.types import NUMERIC_TYPES
 from pandagg.node.aggs.abstract import FieldOrScriptMetricAgg, MetricAgg
-from pandagg.types import Meta
 
 
 class TopHits(MetricAgg):
@@ -86,12 +85,8 @@ class PercentileRanks(FieldOrScriptMetricAgg):
     VALUE_ATTRS = ["values"]
     KEY = "percentile_ranks"
 
-    def __init__(
-        self, field: str, values: List[float], meta: Optional[Meta] = None, **body: Any
-    ) -> None:
-        super(PercentileRanks, self).__init__(
-            field=field, meta=meta, values=values, **body
-        )
+    def __init__(self, field: str, values: List[float], **body: Any) -> None:
+        super(PercentileRanks, self).__init__(field=field, values=values, **body)
 
 
 class ValueCount(FieldOrScriptMetricAgg):

--- a/tests/node/agg/test_bucket.py
+++ b/tests/node/agg/test_bucket.py
@@ -20,6 +20,7 @@ from pandagg.node.aggs import (
     Global,
     Children,
     Parent,
+    SignificantText,
 )
 
 from tests import PandaggTestCase
@@ -872,5 +873,24 @@ def test_parent():
                     "sum_other_doc_count": 0,
                 },
             },
+        )
+    ]
+
+
+def test_significant_text():
+    agg = SignificantText(field="content")
+    assert agg.to_dict() == {"significant_text": {"field": "content"}}
+
+    raw_response = {
+        "doc_count": 100,
+        "buckets": [
+            {"key": "h5n1", "doc_count": 4, "score": 4.71235374214817, "bg_count": 5}
+        ],
+    }
+    assert hasattr(agg.extract_buckets(raw_response), "__iter__")
+    assert list(agg.extract_buckets(raw_response)) == [
+        (
+            "h5n1",
+            {"bg_count": 5, "doc_count": 4, "key": "h5n1", "score": 4.71235374214817},
         )
     ]

--- a/tests/node/agg/test_bucket.py
+++ b/tests/node/agg/test_bucket.py
@@ -21,6 +21,7 @@ from pandagg.node.aggs import (
     Children,
     Parent,
     SignificantText,
+    MultiTerms,
 )
 
 from tests import PandaggTestCase
@@ -893,4 +894,73 @@ def test_significant_text():
             "h5n1",
             {"bg_count": 5, "doc_count": 4, "key": "h5n1", "score": 4.71235374214817},
         )
+    ]
+
+
+def test_multi_terms():
+    agg = MultiTerms(terms=[{"field": "genre"}, {"field": "product"}])
+    assert agg.to_dict() == {
+        "multi_terms": {"terms": [{"field": "genre"}, {"field": "product"}]}
+    }
+
+    raw_response = {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+            {
+                "key": ["rock", "Product A"],
+                "key_as_string": "rock|Product A",
+                "doc_count": 2,
+            },
+            {
+                "key": ["electronic", "Product B"],
+                "key_as_string": "electronic|Product B",
+                "doc_count": 1,
+            },
+            {
+                "key": ["jazz", "Product B"],
+                "key_as_string": "jazz|Product B",
+                "doc_count": 1,
+            },
+            {
+                "key": ["rock", "Product B"],
+                "key_as_string": "rock|Product B",
+                "doc_count": 1,
+            },
+        ],
+    }
+    assert hasattr(agg.extract_buckets(raw_response), "__iter__")
+    assert list(agg.extract_buckets(raw_response)) == [
+        (
+            "rock|Product A",
+            {
+                "doc_count": 2,
+                "key": ["rock", "Product A"],
+                "key_as_string": "rock|Product A",
+            },
+        ),
+        (
+            "electronic|Product B",
+            {
+                "doc_count": 1,
+                "key": ["electronic", "Product B"],
+                "key_as_string": "electronic|Product B",
+            },
+        ),
+        (
+            "jazz|Product B",
+            {
+                "doc_count": 1,
+                "key": ["jazz", "Product B"],
+                "key_as_string": "jazz|Product B",
+            },
+        ),
+        (
+            "rock|Product B",
+            {
+                "doc_count": 1,
+                "key": ["rock", "Product B"],
+                "key_as_string": "rock|Product B",
+            },
+        ),
     ]

--- a/tests/node/agg/test_bucket.py
+++ b/tests/node/agg/test_bucket.py
@@ -17,6 +17,7 @@ from pandagg.node.aggs import (
     IPRange,
     Sampler,
     DiversifiedSampler,
+    Global,
 )
 
 from tests import PandaggTestCase
@@ -777,4 +778,15 @@ def test_diversified_sampler():
                 },
             },
         )
+    ]
+
+
+def test_global():
+    agg = Global(aggs={"avg_price": {"avg": {"field": "price"}}})
+    assert agg.to_dict() == {"global": {}}
+    assert agg._children == {"avg_price": {"avg": {"field": "price"}}}
+    raw_response = {"doc_count": 7, "avg_price": {"value": 140.71428571428572}}
+    assert hasattr(agg.extract_buckets(raw_response), "__iter__")
+    assert list(agg.extract_buckets(raw_response)) == [
+        (None, {"doc_count": 7, "avg_price": {"value": 140.71428571428572}})
     ]


### PR DESCRIPTION
All aggregations are now supported.

- Global
- Children
- Parent
- SignificantText
- MultiTerms