### PR TITLE
Deprecation warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,14 +19,14 @@
 
 # -- Project information -----------------------------------------------------
 
-project = u"pandagg"
-copyright = u"2020, Léonard Binet"
-author = u"Léonard Binet"
+project = "pandagg"
+copyright = "2020, Léonard Binet"
+author = "Léonard Binet"
 
 # The short X.Y version
-version = u""
+version = ""
 # The full version, including alpha/beta/rc tags
-release = u"0.1"
+release = "0.1"
 
 
 # -- General configuration ---------------------------------------------------
@@ -130,7 +130,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "pandagg.tex", u"pandagg Documentation", u"Léonard Binet", "manual")
+    (master_doc, "pandagg.tex", "pandagg Documentation", "Léonard Binet", "manual")
 ]
 
 
@@ -138,7 +138,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "pandagg", u"pandagg Documentation", [author], 1)]
+man_pages = [(master_doc, "pandagg", "pandagg Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------------
@@ -150,7 +150,7 @@ texinfo_documents = [
     (
         master_doc,
         "pandagg",
-        u"pandagg Documentation",
+        "pandagg Documentation",
         author,
         "pandagg",
         "One line description of project.",

--- a/pandagg/index.py
+++ b/pandagg/index.py
@@ -348,7 +348,7 @@ class DeclarativeIndex(metaclass=IndexMeta):
         ``Elasticsearch.indices.create`` unchanged.
         """
         return self._get_connection().indices.create(
-            index=self.name, body=self.to_dict(), **kwargs
+            index=self.name, **self.to_dict(), **kwargs
         )
 
     def is_closed(self) -> bool:

--- a/pandagg/node/mappings/abstract.py
+++ b/pandagg/node/mappings/abstract.py
@@ -72,7 +72,7 @@ class ComplexField(Field):
     def __init__(
         self,
         properties: Optional[Union[Dict, Type[DocumentSource]]] = None,
-        **body: Any
+        **body: Any,
     ) -> None:
         properties = properties or {}
         if not isinstance(properties, dict):

--- a/pandagg/search.py
+++ b/pandagg/search.py
@@ -200,7 +200,7 @@ class Search(DSLMixin, Request):
         on: Optional[QueryName] = None,
         mode: InsertionModes = ADD,
         compound_param: str = None,
-        **body: Any
+        **body: Any,
     ) -> "Search":
         s = self._clone()
         s._query = s._query.query(
@@ -209,7 +209,7 @@ class Search(DSLMixin, Request):
             on=on,
             mode=mode,
             compound_param=compound_param,
-            **body
+            **body,
         )
         return s
 
@@ -224,7 +224,7 @@ class Search(DSLMixin, Request):
         insert_below: Optional[QueryName] = None,
         on: Optional[QueryName] = None,
         mode: InsertionModes = ADD,
-        **body: Any
+        **body: Any,
     ) -> "Search":
         s = self._clone()
         s._query = s._query.bool(
@@ -235,7 +235,7 @@ class Search(DSLMixin, Request):
             insert_below=insert_below,
             on=on,
             mode=mode,
-            **body
+            **body,
         )
         return s
 
@@ -248,7 +248,7 @@ class Search(DSLMixin, Request):
         on: Optional[QueryName] = None,
         mode: InsertionModes = ADD,
         bool_body: ClauseBody = None,
-        **body: Any
+        **body: Any,
     ) -> "Search":
         s = self._clone()
         s._query = s._query.filter(
@@ -257,7 +257,7 @@ class Search(DSLMixin, Request):
             on=on,
             mode=mode,
             bool_body=bool_body,
-            **body
+            **body,
         )
         return s
 
@@ -270,7 +270,7 @@ class Search(DSLMixin, Request):
         on: Optional[QueryName] = None,
         mode: InsertionModes = ADD,
         bool_body: ClauseBody = None,
-        **body: Any
+        **body: Any,
     ) -> "Search":
         s = self._clone()
         s._query = s._query.must_not(
@@ -279,7 +279,7 @@ class Search(DSLMixin, Request):
             on=on,
             mode=mode,
             bool_body=bool_body,
-            **body
+            **body,
         )
         return s
 
@@ -292,7 +292,7 @@ class Search(DSLMixin, Request):
         on: Optional[QueryName] = None,
         mode: InsertionModes = ADD,
         bool_body: ClauseBody = None,
-        **body: Any
+        **body: Any,
     ) -> "Search":
         s = self._clone()
         s._query = s._query.should(
@@ -301,7 +301,7 @@ class Search(DSLMixin, Request):
             on=on,
             mode=mode,
             bool_body=bool_body,
-            **body
+            **body,
         )
         return s
 
@@ -314,7 +314,7 @@ class Search(DSLMixin, Request):
         on: Optional[QueryName] = None,
         mode: InsertionModes = ADD,
         bool_body: ClauseBody = None,
-        **body: Any
+        **body: Any,
     ) -> "Search":
         s = self._clone()
         s._query = s._query.must(
@@ -323,7 +323,7 @@ class Search(DSLMixin, Request):
             on=on,
             mode=mode,
             bool_body=bool_body,
-            **body
+            **body,
         )
         return s
 
@@ -336,7 +336,7 @@ class Search(DSLMixin, Request):
         on: Optional[QueryName] = None,
         mode: InsertionModes = ADD,
         bool_body: ClauseBody = None,
-        **body: Any
+        **body: Any,
     ) -> "Search":
         """Must not wrapped in filter context."""
         s = self._clone()
@@ -356,7 +356,7 @@ class Search(DSLMixin, Request):
         on: Optional[QueryName] = None,
         mode: InsertionModes = ADD,
         compound_param: str = None,
-        **body: Any
+        **body: Any,
     ) -> "Search":
         s = self._clone()
         s._post_filter = s._post_filter.query(
@@ -365,7 +365,7 @@ class Search(DSLMixin, Request):
             on=on,
             mode=mode,
             compound_param=compound_param,
-            **body
+            **body,
         )
         return s
 
@@ -375,7 +375,7 @@ class Search(DSLMixin, Request):
         type_or_agg: Optional[TypeOrAgg] = None,
         insert_below: Optional[AggName] = None,
         at_root: bool_ = False,
-        **body: Any
+        **body: Any,
     ) -> "Search":
         s = self._clone()
         s._aggs = s._aggs.agg(
@@ -383,7 +383,7 @@ class Search(DSLMixin, Request):
             type_or_agg=type_or_agg,
             insert_below=insert_below,
             at_root=at_root,
-            **body
+            **body,
         )
         return s
 
@@ -407,7 +407,7 @@ class Search(DSLMixin, Request):
         type_or_agg: Optional[TypeOrAgg] = None,
         insert_below: Optional[AggName] = None,
         at_root: bool_ = False,
-        **body: Any
+        **body: Any,
     ) -> "Search":
         s = self._clone()
         s._aggs = s._aggs.groupby(
@@ -415,7 +415,7 @@ class Search(DSLMixin, Request):
             type_or_agg=type_or_agg,
             insert_below=insert_below,
             at_root=at_root,
-            **body
+            **body,
         )
         return s
 
@@ -791,7 +791,7 @@ class Search(DSLMixin, Request):
         the data.
         """
         es = self._get_connection()
-        raw_data = es.search(index=self._index, body=self.to_dict())
+        raw_data = es.search(index=self._index, **self.to_dict())  # type: ignore
         return SearchResponse(data=raw_data, _search=self)  # type: ignore
 
     def scan_composite_agg(self, size: int) -> Iterator[BucketDict]:

--- a/pandagg/tree/mappings.py
+++ b/pandagg/tree/mappings.py
@@ -45,7 +45,7 @@ class Mappings(TreeReprMixin, Tree[Field]):
         self,
         properties: Optional[FieldPropertiesDictOrNode] = None,
         dynamic: Optional[bool] = None,
-        **body: Any
+        **body: Any,
     ) -> None:
         super(Mappings, self).__init__()
         # a Mappings always has a root after __init__
@@ -119,7 +119,7 @@ class Mappings(TreeReprMixin, Tree[Field]):
             nid = self.get_node_id_by_path(agg_field.split("."))
         except Exception:
             raise AbsentMappingFieldError(
-                u"Agg of type <%s> on non-existing field <%s>."
+                "Agg of type <%s> on non-existing field <%s>."
                 % (agg_clause.KEY, agg_field)
             )
         _, field_node = self.get(nid)
@@ -129,7 +129,7 @@ class Mappings(TreeReprMixin, Tree[Field]):
             if not exc:
                 return False
             raise InvalidOperationMappingFieldError(
-                u"Agg of type <%s> not possible on field of type <%s>."
+                "Agg of type <%s> not possible on field of type <%s>."
                 % (agg_clause.KEY, field_type)
             )
         return True
@@ -156,7 +156,7 @@ class Mappings(TreeReprMixin, Tree[Field]):
             nid = self.get_node_id_by_path(field_path.split("."))
         except ValueError:
             raise AbsentMappingFieldError(
-                u"<%s field is not present in mappings>" % field_path
+                "<%s field is not present in mappings>" % field_path
             )
         _, node = self.get(nid)
         return node.KEY

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,7 @@ disallow_untyped_defs = True
 
 [mypy-pandas.*]
 ignore_missing_imports = True
+
+[tool:pytest]
+filterwarnings =
+    ignore:.*Elasticsearch built-in security features are not enabled:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,9 @@ def client():
 @fixture
 def write_client(client):
     yield client
-    client.indices.delete("test-*", ignore=404)
-    client.indices.delete_index_template("test-template", ignore=404)
+    client.indices.delete(index="test-git", ignore=404)
+    client.indices.delete(index="test-post", ignore=404)
+    client.indices.delete_index_template(name="test-template", ignore=404)
 
 
 @fixture(scope="session")
@@ -52,13 +53,13 @@ def git_mappings():
 
 @fixture(scope="session")
 def data_client(client):
-    client.indices.delete("git", ignore=(404,))
+    client.indices.delete(index="git", ignore=(404,))
     # create mappings
     create_git_index(client, "git")
     # load data
     bulk(client, TEST_GIT_DATA, raise_on_error=True, refresh=True)
     yield client
-    client.indices.delete("git")
+    client.indices.delete(index="git")
 
 
 @fixture
@@ -109,4 +110,4 @@ def updatable_index(client):
     create_git_index(client, index)
     bulk(client, TEST_GIT_DATA, raise_on_error=True, refresh=True)
     yield index
-    client.indices.delete(index, ignore=404)
+    client.indices.delete(index=index, ignore=404)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -39,34 +39,32 @@ def create_git_index(client, index):
 
     client.indices.create(
         index=index,
-        body={
-            "settings": {
-                # just one shard, no replicas for testing
-                "number_of_shards": 1,
-                "number_of_replicas": 0,
-                # custom analyzer for analyzing file paths
-                "analysis": {
-                    "analyzer": {
-                        "file_path": {
-                            "type": "custom",
-                            "tokenizer": "path_hierarchy",
-                            "filter": ["lowercase"],
-                        }
+        settings={
+            # just one shard, no replicas for testing
+            "number_of_shards": 1,
+            "number_of_replicas": 0,
+            # custom analyzer for analyzing file paths
+            "analysis": {
+                "analyzer": {
+                    "file_path": {
+                        "type": "custom",
+                        "tokenizer": "path_hierarchy",
+                        "filter": ["lowercase"],
                     }
-                },
+                }
             },
-            "mappings": GIT_MAPPINGS,
         },
+        mappings=GIT_MAPPINGS,
     )
 
 
-class TestDocument(TypedDict):
+class _TestDocument(TypedDict):
     _id: str
     _source: Dict[str, Any]
     _index: str
 
 
-TEST_GIT_DATA: List[TestDocument] = [
+TEST_GIT_DATA: List[_TestDocument] = [
     {
         "_id": "3ca6e1e73a071a705b4babd2f581c91a2a3e5037",
         "_source": {

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -62,11 +62,11 @@ def test_index_without_client_raises_error_on_write_op():
 
 
 def test_create_index(write_client):
-    assert not write_client.indices.exists("test-post")
+    assert not write_client.indices.exists(index="test-post")
     index = Post(client=write_client)
     index.save()
-    assert write_client.indices.exists("test-post")
-    persisted_index = write_client.indices.get("test-post")["test-post"]
+    assert write_client.indices.exists(index="test-post")
+    persisted_index = write_client.indices.get(index="test-post")["test-post"]
     assert persisted_index["aliases"] == {"post": {}}
     assert persisted_index["mappings"] == {
         "properties": {"published_from": {"type": "date"}, "title": {"type": "text"}}
@@ -260,7 +260,7 @@ def test_template_save(write_client):
         _source={"title": "salut", "published_from": "2021-01-01"},
     ).perform(refresh=True)
     assert post_index.exists()
-    auto_created_index = write_client.indices.get("test-post")["test-post"]
+    auto_created_index = write_client.indices.get(index="test-post")["test-post"]
     assert auto_created_index["mappings"] == {
         "properties": {"published_from": {"type": "date"}, "title": {"type": "text"}}
     }

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -96,7 +96,7 @@ def test_search_index():
     assert s._index == ["i"]
     s = s.index("i2")
     assert s._index == ["i", "i2"]
-    s = s.index(u"i3")
+    s = s.index("i3")
     assert s._index == ["i", "i2", "i3"]
     s = s.index()
     assert s._index is None
@@ -410,13 +410,13 @@ def test_repr_execution(client_search):
 
     s.size(2).__repr__()
     client_search.assert_called_once()
-    client_search.assert_any_call(body={"size": 2}, index=["yolo"])
+    client_search.assert_any_call(size=2, index=["yolo"])
 
     client_search.reset_mock()
 
     s.size(2)._repr_html_()
     client_search.assert_called_once()
-    client_search.assert_any_call(body={"size": 2}, index=["yolo"])
+    client_search.assert_any_call(size=2, index=["yolo"])
 
 
 @patch.object(Elasticsearch, "search")
@@ -457,14 +457,12 @@ def test_repr_aggs_execution(client_search):
     s.__repr__()
     client_search.assert_called_once()
     client_search.assert_any_call(
-        body={
-            "size": 0,
-            "aggs": {
-                "toto_terms": {
-                    "terms": {"field": "toto"},
-                    "aggs": {"toto_avg_price": {"avg": {"field": "price"}}},
-                }
-            },
+        size=0,
+        aggs={
+            "toto_terms": {
+                "terms": {"field": "toto"},
+                "aggs": {"toto_avg_price": {"avg": {"field": "price"}}},
+            }
         },
         index=["yolo"],
     )

--- a/tests/testing_samples/data_nested_sample.py
+++ b/tests/testing_samples/data_nested_sample.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-EXPECTED_REPR = u""""""
+EXPECTED_REPR = """"""
 
 EXPECTED_AGG_QUERY = {
     "week": {


### PR DESCRIPTION
Fixes multiple deprecation warnings that used to pop while running tests. Most of them were introduced by https://github.com/elastic/elasticsearch-py/issues/1698.

From:
<img width="1031" alt="Screenshot 2022-02-14 at 17 13 22" src="https://user-images.githubusercontent.com/1590371/153902048-1de31645-1c70-4df3-8863-4eaeeaeaf862.png">


To:
<img width="1041" alt="Screenshot 2022-02-14 at 17 13 44" src="https://user-images.githubusercontent.com/1590371/153902083-2c79f245-aab0-4f6b-953a-a171979a9e6e.png">
