### PR TITLE
Fix Search.scan method to allow passing or additional parameters to underlying scan util

### DIFF
--- a/pandagg/search.py
+++ b/pandagg/search.py
@@ -831,18 +831,18 @@ class Search(DSLMixin, Request):
         # artificially merge all buckets as if they were returned in a single query
         return Aggregations(_search=s, data={agg_name: {"buckets": all_buckets}})
 
-    def scan(self) -> Iterator[Hit]:
+    def scan(self, **kwargs: Any) -> Iterator[Hit]:
         """
         Turn the search into a scan search and return a generator that will
         iterate over all the documents matching the query.
 
-        Use ``params`` method to specify any additional arguments you with to
-        pass to the underlying ``scan`` helper from ``elasticsearch-py`` -
+        Use ``kwargs`` to specify any additional arguments to pass to the underlying ``scan`` helper from
+        ``elasticsearch-py`` -
         https://elasticsearch-py.readthedocs.io/en/master/helpers.html#elasticsearch.helpers.scan
 
         """
         es = self._get_connection()
-        for hit in scan(es, query=self.to_dict(), index=self._index):
+        for hit in scan(es, query=self.to_dict(), index=self._index, **kwargs):
             yield Hit(hit, _document_class=self._document_class)
 
     def delete(self) -> DeleteByQueryResponse:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,10 +1,11 @@
 from copy import deepcopy
+from typing import List
 
 from mock import patch
 
 from elasticsearch import Elasticsearch
 
-from pandagg import Aggregations
+from pandagg import Aggregations, Hit
 from pandagg.node.aggs import Max, DateHistogram, Sum
 from pandagg.search import Search
 from pandagg.query import Query, Bool, Match
@@ -468,6 +469,15 @@ def test_repr_aggs_execution(client_search):
         },
         index=["yolo"],
     )
+
+
+def test_scan(data_client):
+    search = Search(using=data_client, index="git")
+    hits_it = search.scan(scroll="1m", size=30)
+    assert hasattr(hits_it, "__iter__")
+    hits: List[Hit] = list(hits_it)
+    assert len(hits) == 52
+    assert all(isinstance(h, Hit) for h in hits)
 
 
 def test_scan_composite_agg(data_client, git_mappings):


### PR DESCRIPTION
replaces https://github.com/alkemics/pandagg/pull/107